### PR TITLE
Add support for healthcheck endpoint

### DIFF
--- a/cmd/server/start_servert.go
+++ b/cmd/server/start_servert.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"log"
+
+	"github.com/Kochava/k8s-demo-chat/internal/broadcast"
+)
+
+func startServer(server broadcast.Server) {
+	if err := server.ListenAndServe(); err != nil {
+		log.Println("server down:", err.Error())
+	}
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
         context: .
         dockerfile: ./docker/chat-server/Dockerfile
-    command: ["/usr/local/bin/chat-server", "-server-addr", "0.0.0.0:4000", "-server-mode", "tcp"]
+    command: ["/usr/local/bin/chat-server", "-server-addr", "0.0.0.0:4000", "-server-mode", "tcp", "-health-addr", "0.0.0.0:5050"]
     volumes:
       - ./contrib/message-schema.json:/tmp/message-schema.json
     ports:
@@ -15,12 +15,17 @@ services:
       - 4000
     links:
       - redis
+    healthcheck:
+        test: curl http://localhost:5050/healthcheck
+        interval: 1s
+        retries: 5
+        timeout: 500ms
 
   websocketserver:
     build:
         context: .
         dockerfile: ./docker/chat-server/Dockerfile
-    command: ["/usr/local/bin/chat-server", "-server-addr", "0.0.0.0:4001", "-server-mode", "ws"]
+    command: ["/usr/local/bin/chat-server", "-server-addr", "0.0.0.0:4001", "-server-mode", "ws", "-health-addr", "0.0.0.0:5050"]
     volumes:
       - ./contrib/message-schema.json:/tmp/message-schema.json
     ports:
@@ -29,6 +34,11 @@ services:
       - 4001
     links:
       - redis
+    healthcheck:
+        test: curl http://localhost:5050/healthcheck
+        interval: 1s
+        retries: 5
+        timeout: 500ms
 
   redis:
     image: redis:3.2-alpine

--- a/internal/build/config.go
+++ b/internal/build/config.go
@@ -1,6 +1,9 @@
 package build
 
-import "github.com/Kochava/k8s-demo-chat/internal/build/redis"
+import (
+	"github.com/Kochava/k8s-demo-chat/internal/build/healthcheck"
+	"github.com/Kochava/k8s-demo-chat/internal/build/redis"
+)
 
 // Config stores application configuration variables
 type Config struct {
@@ -8,11 +11,13 @@ type Config struct {
 	ServerAddr               string
 	ServerMode               string
 	JSONValidationSchemaPath string
+	Health                   *healthcheck.Config
 }
 
 // NewConfig initializes an empty config
 func NewConfig() *Config {
 	return &Config{
-		Redis: &redis.Config{},
+		Redis:  &redis.Config{},
+		Health: &healthcheck.Config{},
 	}
 }

--- a/internal/build/healthcheck/build.go
+++ b/internal/build/healthcheck/build.go
@@ -1,0 +1,21 @@
+package healthcheck
+
+import "net/http"
+
+func Build(config *Config) *http.Server {
+	var (
+		mux    = http.NewServeMux()
+		server = &http.Server{
+			Addr: config.Addr,
+		}
+	)
+
+	mux.HandleFunc(config.Path, func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("healthy"))
+	})
+
+	server.Handler = mux
+
+	return server
+}

--- a/internal/build/healthcheck/config.go
+++ b/internal/build/healthcheck/config.go
@@ -1,0 +1,7 @@
+package healthcheck
+
+// Config describes a healthcheck service
+type Config struct {
+	Addr string
+	Path string
+}

--- a/internal/build/prepare_flags.go
+++ b/internal/build/prepare_flags.go
@@ -10,4 +10,6 @@ func PrepareFlags(config *Config) {
 	flag.StringVar(&config.ServerAddr, "server-addr", "", "The address to listen on")
 	flag.StringVar(&config.ServerMode, "server-mode", "ws", "The server mode (tcp, ws)")
 	flag.StringVar(&config.JSONValidationSchemaPath, "json-validation-schema-path", "file:///tmp/message-schema.json", "The location of the JSON validation file")
+	flag.StringVar(&config.Health.Addr, "health-addr", "", "The address to listen on for healthcheck requests")
+	flag.StringVar(&config.Health.Path, "health-path", "/healthcheck", "The endpoint to response to for healthchecks")
 }


### PR DESCRIPTION
**Summary**

A second port now hosts a http server for health checks. It will bind to the specified address
and uses the specified endpoint path. Healthy responses will have a 200 status code and the body 
will say `healthy`

**New flags**

flag                   | required | sample
---------------|----------|----------
`-health-addr` | yes         | `0.0.0.0:5050`
`-health-path` | no           | `/healthcheck`