### PR TITLE
Embed the healthcheck.

### DIFF
--- a/internal/websocketutil/server.go
+++ b/internal/websocketutil/server.go
@@ -20,7 +20,10 @@ func (server *Server) ListenAndServe() error {
 		mux = http.NewServeMux()
 	)
 
-	mux.Handle("/", server.HandleFunc)
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("OK"))
+	}))
+	mux.Handle("/chat", server.HandleFunc)
 
 	server.httpServer = &http.Server{
 		Addr:    server.Addr,


### PR DESCRIPTION
GCE ingress for GKE does not have the flexibility to 1) easily add
healthchecks that run on different ports and 2) healthchecks on the load
balancers cannot upgrade websocket connections which is what the
original route set for the root path.  This change swaps the root
path with a standard http response that the web check can use and puts
the websocket handler under /chat.